### PR TITLE
Feature/pt i18n and dynamic event data

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -52,6 +52,8 @@ page '/*.txt', layout: false
 #   activate :minify_javascript, compressor: Terser.new
 # end
 
+activate :i18n, locales: [:'pt-br'], mount_at_root: :'pt-br'
+
 require 'dotenv/load'
 require 'rqrcode'
 

--- a/data/event.yml
+++ b/data/event.yml
@@ -1,0 +1,8 @@
+edition: 21
+
+date:
+  year: 2026
+  month: 6
+  day: 28
+
+venue: "Estádio de Toyota"

--- a/data/infos.yml
+++ b/data/infos.yml
@@ -1,5 +1,5 @@
 - name: "Data do Evento"
-  description: "A 21ª Festa Junina Beneficente ocorrerá em <strong> 28 de Junho de 2026 </strong>. Marquem seus calendários!"
+  description: "A %{edition}ª Festa Junina Beneficente ocorrerá em <strong>%{date}</strong>. Marquem seus calendários!"
   color: "yellow"
 - name: "Estacionamento"
   description: "Haverá vagas gratuitas disponíveis no estádio e em seus arredores."

--- a/locales/pt-br.yml
+++ b/locales/pt-br.yml
@@ -1,0 +1,36 @@
+pt-br:
+  date:
+    month_names:
+      [
+        null,
+        Janeiro,
+        Fevereiro,
+        Março,
+        Abril,
+        Maio,
+        Junho,
+        Julho,
+        Agosto,
+        Setembro,
+        Outubro,
+        Novembro,
+        Dezembro,
+      ]
+    abbr_month_names:
+      [null, Jan, Fev, Mar, Abr, Mai, Jun, Jul, Ago, Set, Out, Nov, Dez]
+    day_names:
+      [
+        Domingo,
+        Segunda-feira,
+        Terça-feira,
+        Quarta-feira,
+        Quinta-feira,
+        Sexta-feira,
+        Sábado,
+      ]
+    abbr_day_names: [Dom, Seg, Ter, Qua, Qui, Sex, Sáb]
+  time:
+    formats:
+      default: "%d de %B"
+      short: "%d/%m "
+      long: "%d de %B de %Y"

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="pt-BR">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">

--- a/source/partials/_footer.html.erb
+++ b/source/partials/_footer.html.erb
@@ -1,11 +1,21 @@
+<% event_date = I18n.l(
+   Time.new(
+      data.event.date.year, 
+      data.event.date.month, 
+      data.event.date.day
+   ), 
+   format: :long) 
+%>
+
+
 <div id="footer">
    <div class="footer-content">
       <div class="about">
-         <h3>21ª Festa Junina Beneficente da Igreja Católica</h3>
+         <h3><%= data.event.edition %>ª Festa Junina Beneficente da Igreja Católica</h3>
          <div class="icons grid">
             <div class="icon area-1">
                <i class="fa-solid fa-calendar fa-lg"></i>
-               <p>28 de Junho de 2026</p>
+               <p><%= event_date %></p>
             </div>
          <div class="icon area-2">
                <i class="fa-solid fa-clock fa-lg"></i>
@@ -13,7 +23,7 @@
          </div>
             <div class="icon area-3">
                <i class="fa-solid fa-location-dot fa-lg"></i>
-               <p>Estádio de Toyota</p>
+               <p><%= data.event.venue %></p>
          </div>
          </div>
       </div>

--- a/source/partials/_hero_page.html.erb
+++ b/source/partials/_hero_page.html.erb
@@ -1,11 +1,19 @@
+<% event_date = I18n.l(
+  Time.new(
+    data.event.date.year, 
+    data.event.date.month, 
+    data.event.date.day), 
+  format: :default
+) %>
+
 <div id="hero-page">
   <div class="intro">
-    <h1>21ª Festa Junina Beneficente</h1>
+    <h1><%= data.event.edition %>ª Festa Junina Beneficente</h1>
     <h3>Comunidade Católica de Toyota</h3>
   </div>
 
   <div class="intro-text">
-    <p> Venha celebrar conosco a 21ª Festa Junina Beneficente da Comunidade Católica de Toyota! 🌽🎶 No dia 28 de Junho, prepare-se para um dia inesquecível, cheia de música, dança, comidas típicas e muita diversão! Teremos barracas com delícias tradicionais, brincadeiras para todas as idades e, claro, o famoso bingo com prêmios incríveis! Traga sua família e amigos para vivenciar essa linda tradição brasileira em um ambiente acolhedor e festivo. Não perca essa grande festa! Esperamos por você! 🎉🔥</p>
+    <p> Venha celebrar conosco a <%= data.event.edition %>ª Festa Junina Beneficente da Comunidade Católica de Toyota! 🌽🎶 No dia <%= event_date %>, prepare-se para um dia inesquecível, cheia de música, dança, comidas típicas e muita diversão! Teremos barracas com delícias tradicionais, brincadeiras para todas as idades e, claro, o famoso bingo com prêmios incríveis! Traga sua família e amigos para vivenciar essa linda tradição brasileira em um ambiente acolhedor e festivo. Não perca essa grande festa! Esperamos por você! 🎉🔥</p>
 
     <%= image_tag "stadium.png", class: 'stadium-img', alt: 'Foto do Estádio de Toyota' %>
   </div>

--- a/source/partials/_info_board.html.erb
+++ b/source/partials/_info_board.html.erb
@@ -1,3 +1,5 @@
+<% event_date = I18n.l(Time.new(2026, 6, 28), format: :long) %>
+
 <div class="quadro-avisos">
   <div class="board">
       <div class="post-it-wrapper">
@@ -6,7 +8,19 @@
                <i class="fa-solid fa-circle pin" style="color: #ab0d0d;"></i>
                <div class="info-content">
                   <h3><%= info.name class: "info-title" %></h3>
-                  <p><%= info.description class: 'info-body' %></p>
+                  <p class="info-body">
+                     <%= (info.description % {
+                        edition: data.event.edition,
+                        date: I18n.l(
+                           Time.new(
+                              data.event.date.year, 
+                              data.event.date.month, 
+                              data.event.date.day
+                           ),
+                           format: :long
+                        )
+                     }).html_safe %>
+                  </p>
                </div>
             </div>
          <% end %>


### PR DESCRIPTION
This PR sets up Portuguese (pt-BR) localization and refactors event information to use dynamic data

## Changes
- Enable Middleman i18n support for pt-BR
- Centralize event metadata in `data/event.yml`
- Add localized date formatting using I18n
- Update layout to include proper `lang="pt-BR"` attribute
- Refactor info/partials to use dynamic event data interpolation
