### PR TITLE
Fix/build config and mapbox

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,8 @@ jobs:
           bundler-cache: true
 
       - name: Build Middleman Site
+        env:
+          MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
         run: bundle exec middleman build --clean
 
       - name: Deploy to Github Pages

--- a/config.rb
+++ b/config.rb
@@ -10,7 +10,6 @@ end
 
 configure :build do
   activate :relative_assets
-  set :relative_links, true
 end
 
 set :base_url, "/"


### PR DESCRIPTION
Fix asset paths and Mapbox token in build pipeline
- Remove `set :relative_links, true` from build config
- Add MAPBOX_ACCESS_TOKEN env variable to the build step in the deploy workflow so the token gets baked into the static output at build time
